### PR TITLE
Fix Step 11 gaps: archived game section and status redirect

### DIFF
--- a/app/blueprints/playing.py
+++ b/app/blueprints/playing.py
@@ -24,7 +24,14 @@ def index():
         Game.query.filter_by(section="active", status="On Hold")
         .order_by(Game.name).all()
     )
-    return render_template("playing/index.html", playing=playing, on_hold=on_hold)
+    archived = (
+        Game.query.filter(
+            Game.section == "active",
+            Game.status.in_(["Dropped", "Completed"]),
+        )
+        .order_by(Game.status, Game.name).all()
+    )
+    return render_template("playing/index.html", playing=playing, on_hold=on_hold, archived=archived)
 
 
 @playing_bp.route("/<int:game_id>")
@@ -98,7 +105,7 @@ def set_status(game_id):
     if new_status in STATUSES:
         game.status = new_status
         db.session.commit()
-    return redirect(url_for("playing.index"))
+    return redirect(url_for("playing.detail", game_id=game_id))
 
 
 @playing_bp.route("/<int:game_id>/delete", methods=["POST"])

--- a/app/templates/playing/index.html
+++ b/app/templates/playing/index.html
@@ -111,4 +111,18 @@
 <p class="text-gray-500">No active games yet.</p>
 {% endif %}
 
+<!-- Archived (Dropped / Completed) -->
+{% if archived %}
+<details class="mt-10">
+  <summary class="cursor-pointer text-sm text-gray-500 hover:text-gray-300 transition-colors select-none">
+    Archived ({{ archived|length }})
+  </summary>
+  <div class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 mt-4">
+    {% for game in archived %}
+      {{ game_card(game) }}
+    {% endfor %}
+  </div>
+</details>
+{% endif %}
+
 {% endblock %}


### PR DESCRIPTION
## Summary

- Add a collapsible \"Archived\" section to the active library index showing Dropped/Completed games (satisfies Step 11's toggle/tab requirement)
- Redirect `set_status` back to the game's detail page instead of the index, so the updated status is visible after a change rather than the game silently disappearing

## Test plan

- [x] Mark a game as Dropped or Completed — confirm you land back on the detail page with the correct status highlighted
- [x] Return to the active library index — confirm the game is absent from Playing/On Hold sections
- [x] Expand the \"Archived\" summary — confirm the game appears with the correct status badge
- [x] Verify Playing and On Hold sections are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)