### PR TITLE
Add category rename (Step 13 gap)

### DIFF
--- a/app/blueprints/backlog.py
+++ b/app/blueprints/backlog.py
@@ -116,6 +116,17 @@ def categories():
     return render_template("backlog/categories.html", categories=all_cats)
 
 
+@backlog_bp.route("/categories/<int:cat_id>/rename", methods=["POST"])
+def rename_category(cat_id):
+    cat = db.get_or_404(Category, cat_id)
+    name = request.form.get("name", "").strip()
+    if name:
+        cat.name = name
+        db.session.commit()
+        flash(f"Category renamed to '{name}'.", "success")
+    return redirect(url_for("backlog.categories"))
+
+
 @backlog_bp.route("/categories/<int:cat_id>/delete", methods=["POST"])
 def delete_category(cat_id):
     cat = db.get_or_404(Category, cat_id)

--- a/app/templates/backlog/categories.html
+++ b/app/templates/backlog/categories.html
@@ -23,11 +23,17 @@
   {% if categories %}
   <ul class="flex flex-col gap-2">
     {% for cat in categories %}
-    <li class="flex items-center justify-between bg-gray-900 rounded-lg px-4 py-3">
-      <div>
-        <span class="font-medium">{{ cat.name }}</span>
-        <span class="ml-2 text-xs text-gray-500">{{ cat.games | length }} game{{ 's' if cat.games | length != 1 }}</span>
-      </div>
+    <li class="flex items-center gap-3 bg-gray-900 rounded-lg px-4 py-3">
+      <form method="post" action="{{ url_for('backlog.rename_category', cat_id=cat.id) }}"
+            class="flex items-center gap-2 flex-1 min-w-0">
+        <input name="name" type="text" value="{{ cat.name }}" required
+               class="flex-1 min-w-0 bg-transparent border-b border-gray-700 focus:border-indigo-500 focus:outline-none text-sm font-medium py-0.5">
+        <button type="submit"
+                class="text-xs text-gray-500 hover:text-white transition-colors shrink-0">
+          Rename
+        </button>
+      </form>
+      <span class="text-xs text-gray-500 shrink-0">{{ cat.games | length }} game{{ 's' if cat.games | length != 1 }}</span>
       <form method="post" action="{{ url_for('backlog.delete_category', cat_id=cat.id) }}"
             onsubmit="return confirm('Delete category \'{{ cat.name }}\'? Its games will become uncategorized.')">
         <button type="submit"


### PR DESCRIPTION
## Summary

- Add `POST /backlog/categories/<id>/rename` route
- Replace the static category name display in the categories template with an inline editable input — submit with the "Rename" button to save in place

## Test plan

- [x] Navigate to Backlog → Categories
- [x] Edit a category name inline and click Rename — confirm flash and updated name
- [x] Submit an empty name — confirm it is rejected (browser required validation)
- [x] Confirm create and delete still work as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)