### PR TITLE
Fix Steps 17 & 18: nav active state and top-per-category dashboard

### DIFF
--- a/app/blueprints/main.py
+++ b/app/blueprints/main.py
@@ -12,13 +12,9 @@ def index():
     backlog_count   = Game.query.filter_by(section="backlog").count()
     completed_count = Game.query.filter_by(status="Completed").count()
 
-    top_backlog = (
-        Game.query
-        .filter_by(section="backlog")
-        .order_by(Game.rank)
-        .limit(5)
-        .all()
-    )
+    # Top-ranked game per category (relationship already orders by rank)
+    categories = Category.query.order_by(Category.name).all()
+    top_backlog = [cat.games[0] for cat in categories if cat.games]
 
     return render_template(
         "main/index.html",

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -12,11 +12,11 @@
   <nav class="bg-gray-900 border-b border-gray-800 px-6 py-3 flex items-center gap-6">
     <span class="font-bold text-lg tracking-tight">Game Journal</span>
     <a href="{{ url_for('main.index') }}"
-       class="text-sm text-gray-400 hover:text-white transition-colors">Dashboard</a>
+       class="text-sm transition-colors {{ 'text-white font-medium' if request.path == '/' else 'text-gray-400 hover:text-white' }}">Dashboard</a>
     <a href="{{ url_for('playing.index') }}"
-       class="text-sm text-gray-400 hover:text-white transition-colors">Playing</a>
+       class="text-sm transition-colors {{ 'text-white font-medium' if request.path.startswith('/playing') else 'text-gray-400 hover:text-white' }}">Playing</a>
     <a href="{{ url_for('backlog.index') }}"
-       class="text-sm text-gray-400 hover:text-white transition-colors">Backlog</a>
+       class="text-sm transition-colors {{ 'text-white font-medium' if request.path.startswith('/backlog') else 'text-gray-400 hover:text-white' }}">Backlog</a>
   </nav>
 
   <main class="px-6 py-8 max-w-5xl mx-auto">

--- a/app/templates/main/index.html
+++ b/app/templates/main/index.html
@@ -27,7 +27,7 @@
 <!-- Top backlog picks -->
 {% if top_backlog %}
 <section>
-  <h2 class="text-lg font-semibold text-gray-300 mb-4">Top Backlog Picks</h2>
+  <h2 class="text-lg font-semibold text-gray-300 mb-4">Top Pick per Category</h2>
   <div class="flex flex-col gap-2">
     {% for game in top_backlog %}
     <div class="bg-gray-900 rounded-lg flex items-center gap-4 px-4 py-3">


### PR DESCRIPTION
## Summary

- **Step 17**: Add active nav highlighting — current section is `text-white font-medium`, others remain `text-gray-400`, using `request.path` conditionals in `base.html`
- **Step 18**: Replace the global top-5 backlog query with the top-ranked game per category by iterating `Category.games` (already ordered by rank via the relationship's `order_by`)

## Test plan

- [x] Visit each page — confirm the correct nav link is bold/white
- [x] Dashboard shows one entry per category, each being that category's rank-1 game
- [x] Categories with no games are omitted from the dashboard list
- [x] Stat cards (Playing, On Hold, Backlog, Completed) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)