### PR TITLE
Add systemd service template and production config selection (Steps 22-23)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 FLASK_SECRET_KEY=your-secret-key-here
 DATABASE_URL=mysql+pymysql://user:password@host/dbname
-FLASK_ENV=development
+FLASK_ENV=production   # set to "development" locally
 RAWG_API_KEY=your-rawg-api-key-here
 TAILSCALE_IP=100.x.x.x
 PORT=5000

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,4 @@
+import os
 from flask import Flask, render_template
 from flask_sqlalchemy import SQLAlchemy
 from config import config
@@ -5,7 +6,9 @@ from config import config
 db = SQLAlchemy()
 
 
-def create_app(config_name="default"):
+def create_app(config_name=None):
+    if config_name is None:
+        config_name = os.environ.get("FLASK_ENV", "development")
     app = Flask(__name__)
     app.config.from_object(config[config_name])
 

--- a/deploy/game-journal.service
+++ b/deploy/game-journal.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Game Journal
+After=network.target
+
+[Service]
+User=<your-linux-user>
+WorkingDirectory=/path/to/game-journal
+EnvironmentFile=/path/to/game-journal/.env
+ExecStart=/path/to/game-journal/.venv/bin/gunicorn \
+    -w 2 \
+    -b <tailscale-ip>:<port> \
+    "app:create_app()"
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

- `create_app()` now reads `FLASK_ENV` from the environment to select the config object, defaulting to `"development"`. Set `FLASK_ENV=production` in `.env` on the server and `ProductionConfig` (`DEBUG=False`) is used automatically — no change needed to the Gunicorn command.
- Add `deploy/game-journal.service` as a systemd unit file template. Fill in `<your-linux-user>`, `/path/to/game-journal`, `<tailscale-ip>`, and `<port>`, then copy to `/etc/systemd/system/` to enable auto-start on reboot.
- Update `.env.example` to clarify `FLASK_ENV=production` is the server value.

## Deployment steps (for reference)
```bash
# Copy and edit the service file
sudo cp deploy/game-journal.service /etc/systemd/system/game-journal.service
sudo systemctl daemon-reload
sudo systemctl enable game-journal
sudo systemctl start game-journal
```

## Test plan

- [x] Locally: `python run.py` still works with `FLASK_ENV=development`
- [ ] Confirm `create_app("production")` still works when passed explicitly (e.g. for tests)
- [x] On server: `FLASK_ENV=production` in `.env` → `app.debug` is `False`

🤖 Generated with [Claude Code](https://claude.com/claude-code)