### PR TITLE
Update README to reflect completed phases 6–8

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,13 @@ Access is restricted entirely by Tailscale — no login system. If you're on the
 
 **Backlog Manager**
 - Organize unplayed games into user-defined categories
+- Rename categories in place
 - Drag-and-drop to reorder games within each category
 - One-click promote to active library
+
+**Dashboard**
+- At-a-glance stats: active game count, backlog size, completed count
+- Top game per backlog category
 
 ---
 
@@ -34,7 +39,9 @@ Access is restricted entirely by Tailscale — no login system. If you're on the
 | Styling | Tailwind CSS (CDN) |
 | Drag-and-Drop | SortableJS (CDN) |
 | Production Server | Gunicorn |
+| Environment Vars | python-dotenv |
 | Network / Auth | Tailscale |
+| Game Metadata API | RAWG (rawg.io) |
 
 ---
 
@@ -45,17 +52,22 @@ game-journal/
 ├── app/
 │   ├── __init__.py          # App factory, db init, blueprint registration
 │   ├── models.py            # SQLAlchemy models: Game, Category
+│   ├── seeds.py             # flask seed CLI command
 │   ├── blueprints/
-│   │   ├── main.py          # Dashboard route (/)
+│   │   ├── main.py          # Dashboard (/) and RAWG search proxy
 │   │   ├── playing.py       # Active library routes (/playing)
 │   │   └── backlog.py       # Backlog routes (/backlog)
+│   ├── utils/
+│   │   └── rawg.py          # RAWG API helpers
 │   ├── templates/
 │   │   ├── base.html        # Base template with nav and CDN links
 │   │   ├── main/
 │   │   ├── playing/
 │   │   └── backlog/
 │   └── static/
-├── config.py                # Flask config classes, loads from .env
+├── deploy/
+│   └── game-journal.service # systemd unit template
+├── config.py                # DevelopmentConfig / ProductionConfig, loads from .env
 ├── run.py                   # Entry point for local dev
 ├── requirements.txt
 └── .env                     # Secrets — never commit
@@ -67,6 +79,8 @@ game-journal/
 
 **1. Install dependencies**
 ```bash
+python3 -m venv .venv
+source .venv/bin/activate
 pip install -r requirements.txt
 ```
 
@@ -75,20 +89,26 @@ pip install -r requirements.txt
 FLASK_SECRET_KEY=your-secret-key-here
 DATABASE_URL=mysql+pymysql://user:password@host/dbname
 FLASK_ENV=development
+RAWG_API_KEY=your-rawg-api-key        # from rawg.io/apidocs — free account
+TAILSCALE_IP=100.x.x.x                # from: tailscale ip -4
+PORT=5000
 ```
 
 **3. Initialize the database**
 ```bash
 flask shell
->>> from app import db
+>>> from app import db, models
 >>> db.create_all()
 ```
 
-**4. Run locally**
+**4. (Optional) Seed with example data**
+```bash
+flask seed
+```
+
+**5. Run locally**
 ```bash
 python run.py
-# or
-flask run
 ```
 
 ---
@@ -101,4 +121,4 @@ Runs under Gunicorn, bound to the server's Tailscale IP only (never `0.0.0.0`):
 gunicorn -w 2 -b <tailscale-ip>:<port> "app:create_app()"
 ```
 
-Managed via a `systemd` service for auto-restart on reboot. Secrets are loaded from `.env` at startup via `python-dotenv`.
+A `systemd` unit template is provided at `deploy/game-journal.service` for auto-restart on reboot. Secrets are loaded from `.env` at startup via `python-dotenv`.


### PR DESCRIPTION
## Summary

- Adds RAWG API key, Tailscale IP, and PORT to the setup env vars section
- Documents category rename, dashboard stats, and top-per-category features
- Adds `deploy/` directory and systemd service to the project structure tree
- Adds `utils/rawg.py` and `seeds.py` to the structure tree
- Updates setup steps to use a virtualenv and the correct `from app import db, models` shell incantation
- Notes `DevelopmentConfig / ProductionConfig` in config.py description

## Test plan
- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all described features and paths exist in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)