### PR TITLE
Refactor for cohesion: shared helpers, macros, and star JS

### DIFF
--- a/app/blueprints/backlog.py
+++ b/app/blueprints/backlog.py
@@ -1,19 +1,13 @@
 from flask import Blueprint, render_template, redirect, url_for, request, flash, jsonify
 from app import db
 from app.models import Game, Category
+from app.utils.helpers import _int
 
 backlog_bp = Blueprint("backlog", __name__)
 
 # ------------------------------------------------------------------ #
 # Helpers                                                              #
 # ------------------------------------------------------------------ #
-
-def _int(value):
-    try:
-        return int(value) if value else None
-    except (ValueError, TypeError):
-        return None
-
 
 _LENGTH_SCORES = {"Short": 20, "Medium": 10, "Long": 5, "Very Long": 0}
 

--- a/app/blueprints/playing.py
+++ b/app/blueprints/playing.py
@@ -1,17 +1,9 @@
 from flask import Blueprint, render_template, redirect, url_for, request, flash
 from app import db
-from app.models import Game, CheckIn
+from app.models import Game, CheckIn, STATUSES
+from app.utils.helpers import _int, _float
 
 playing_bp = Blueprint("playing", __name__)
-
-STATUSES = ["Playing", "On Hold", "Dropped", "Completed"]
-
-
-def _int(value):
-    try:
-        return int(value) if value else None
-    except (ValueError, TypeError):
-        return None
 
 
 @playing_bp.route("/")
@@ -135,7 +127,7 @@ def checkin(game_id):
         motivation=new_motivation,
         enjoyment=new_enjoyment,
         note=request.form.get("note", "").strip() or None,
-        hours_played=request.form.get("hours_played") or None,
+        hours_played=_float(request.form.get("hours_played")),
         status=new_status if new_status in STATUSES else None,
     )
 

--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,8 @@
 from datetime import datetime
 from app import db
 
+STATUSES = ["Playing", "On Hold", "Dropped", "Completed"]
+
 
 class Category(db.Model):
     __tablename__ = "categories"

--- a/app/templates/backlog/add.html
+++ b/app/templates/backlog/add.html
@@ -132,20 +132,6 @@
 </div>
 
 <script>
-// Star rating (hype)
-document.querySelectorAll('.star-btn').forEach(function(btn) {
-  btn.addEventListener('click', function() {
-    var group = this.dataset.group;
-    var val   = parseInt(this.dataset.val);
-    document.getElementById(group + '-val').value = val;
-    document.querySelectorAll('[data-group="' + group + '"]').forEach(function(b) {
-      var bVal = parseInt(b.dataset.val);
-      b.classList.toggle('text-yellow-400', bVal <= val);
-      b.classList.toggle('text-gray-600',   bVal >  val);
-    });
-  });
-});
-
 // RAWG search
 function doSearch() {
   var q = document.getElementById('rawg-search').value.trim();

--- a/app/templates/backlog/play_next.html
+++ b/app/templates/backlog/play_next.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "macros.html" import stars %}
 {% block title %}Play Next — Game Journal{% endblock %}
 
 {% block content %}
@@ -70,9 +71,7 @@
           <span class="text-xs text-indigo-400 font-medium">Series</span>
         {% endif %}
         {% if game.hype %}
-          <span class="text-xs text-yellow-400" title="Hype: {{ game.hype }}/5">
-            {% for i in range(1, 6) %}{{ '★' if i <= game.hype else '☆' }}{% endfor %}
-          </span>
+          <span class="text-xs" title="Hype: {{ game.hype }}/5">{{ stars(game.hype) }}</span>
         {% endif %}
         {{ mood_bars(game) }}
       </div>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -37,5 +37,23 @@
     {% block content %}{% endblock %}
   </main>
 
+{% block scripts %}
+<script>
+// Star rating handler — shared across all pages with .star-btn elements.
+document.querySelectorAll('.star-btn').forEach(function(btn) {
+  btn.addEventListener('click', function() {
+    var group = this.dataset.group;
+    var val   = parseInt(this.dataset.val);
+    document.getElementById(group + '-val').value = val;
+    document.querySelectorAll('[data-group="' + group + '"]').forEach(function(b) {
+      var bVal = parseInt(b.dataset.val);
+      b.classList.toggle('text-yellow-400', bVal <= val);
+      b.classList.toggle('text-gray-600',   bVal >  val);
+    });
+  });
+});
+</script>
+{% endblock %}
+
 </body>
 </html>

--- a/app/templates/macros.html
+++ b/app/templates/macros.html
@@ -1,0 +1,1 @@
+{% macro stars(value, max=5) %}<span class="text-yellow-400 tracking-tight">{% for i in range(1, max + 1) %}{% if value and i <= value %}★{% else %}<span class="text-gray-600">★</span>{% endif %}{% endfor %}</span>{% endmacro %}

--- a/app/templates/main/index.html
+++ b/app/templates/main/index.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "macros.html" import stars %}
 {% block title %}Dashboard — Game Journal{% endblock %}
 
 {% block content %}
@@ -50,9 +51,7 @@
             <span class="text-xs text-gray-600">{{ game.estimated_length }}</span>
           {% endif %}
           {% if game.hype %}
-            <span class="text-xs text-yellow-400">
-              {% for i in range(1, 6) %}{{ '★' if i <= game.hype else '☆' }}{% endfor %}
-            </span>
+            <span class="text-xs">{{ stars(game.hype) }}</span>
           {% endif %}
         </div>
       </div>

--- a/app/templates/playing/detail.html
+++ b/app/templates/playing/detail.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from "macros.html" import stars %}
 {% block title %}{{ game.name }} — Game Journal{% endblock %}
 
 {% block content %}
@@ -75,20 +76,12 @@
     <div class="flex flex-col gap-2 text-sm">
       <div class="flex items-center gap-3">
         <span class="w-20 text-gray-400">Enjoyment</span>
-        <span class="text-yellow-400 tracking-tight">
-          {% for i in range(1, 6) %}
-            {% if game.enjoyment and i <= game.enjoyment %}★{% else %}<span class="text-gray-700">★</span>{% endif %}
-          {% endfor %}
-        </span>
+        {{ stars(game.enjoyment) }}
         {% if not game.enjoyment %}<span class="text-gray-600 text-xs">unrated</span>{% endif %}
       </div>
       <div class="flex items-center gap-3">
         <span class="w-20 text-gray-400">Motivation</span>
-        <span class="text-yellow-400 tracking-tight">
-          {% for i in range(1, 6) %}
-            {% if game.motivation and i <= game.motivation %}★{% else %}<span class="text-gray-700">★</span>{% endif %}
-          {% endfor %}
-        </span>
+        {{ stars(game.motivation) }}
         {% if not game.motivation %}<span class="text-gray-600 text-xs">unrated</span>{% endif %}
       </div>
     </div>
@@ -118,11 +111,7 @@
       <div class="flex items-center gap-3">
         <span class="w-28 text-gray-400">Overall rating</span>
         {% if game.overall_rating %}
-          <span class="text-yellow-400 tracking-tight">
-            {% for i in range(1, 11) %}
-              {% if i <= game.overall_rating %}★{% else %}<span class="text-gray-700">★</span>{% endif %}
-            {% endfor %}
-          </span>
+          {{ stars(game.overall_rating, max=10) }}
           <span class="text-gray-500 text-xs">({{ game.overall_rating }}/10)</span>
         {% else %}
           <span class="text-gray-600 text-xs">unrated</span>
@@ -139,11 +128,7 @@
       <div class="flex items-center gap-3">
         <span class="w-28 text-gray-400">Difficulty</span>
         {% if game.difficulty %}
-          <span class="text-yellow-400 tracking-tight">
-            {% for i in range(1, 6) %}
-              {% if i <= game.difficulty %}★{% else %}<span class="text-gray-700">★</span>{% endif %}
-            {% endfor %}
-          </span>
+          {{ stars(game.difficulty) }}
         {% else %}
           <span class="text-gray-600 text-xs">unrated</span>
         {% endif %}
@@ -176,18 +161,10 @@
         </div>
         <div class="flex flex-wrap gap-x-4 gap-y-1 text-xs text-gray-400 mb-1">
           {% if ci.enjoyment %}
-            <span>Enjoyment
-              <span class="text-yellow-400">
-                {% for i in range(1, 6) %}{% if i <= ci.enjoyment %}★{% else %}<span class="text-gray-700">★</span>{% endif %}{% endfor %}
-              </span>
-            </span>
+            <span>Enjoyment {{ stars(ci.enjoyment) }}</span>
           {% endif %}
           {% if ci.motivation %}
-            <span>Motivation
-              <span class="text-yellow-400">
-                {% for i in range(1, 6) %}{% if i <= ci.motivation %}★{% else %}<span class="text-gray-700">★</span>{% endif %}{% endfor %}
-              </span>
-            </span>
+            <span>Motivation {{ stars(ci.motivation) }}</span>
           {% endif %}
           {% if ci.hours_played %}
             <span>{{ ci.hours_played }}h</span>

--- a/app/templates/playing/finish_survey.html
+++ b/app/templates/playing/finish_survey.html
@@ -72,18 +72,4 @@
   </form>
 </div>
 
-<script>
-document.querySelectorAll('.star-btn').forEach(function(btn) {
-  btn.addEventListener('click', function() {
-    var group = this.dataset.group;
-    var val   = parseInt(this.dataset.val);
-    document.getElementById(group + '-val').value = val;
-    document.querySelectorAll('[data-group="' + group + '"]').forEach(function(b) {
-      var bVal = parseInt(b.dataset.val);
-      b.classList.toggle('text-yellow-400', bVal <= val);
-      b.classList.toggle('text-gray-600',   bVal >  val);
-    });
-  });
-});
-</script>
 {% endblock %}

--- a/app/templates/playing/form.html
+++ b/app/templates/playing/form.html
@@ -100,20 +100,6 @@
 </div>
 
 <script>
-// Star rating buttons
-document.querySelectorAll('.star-btn').forEach(function(btn) {
-  btn.addEventListener('click', function() {
-    var group = this.dataset.group;
-    var val   = parseInt(this.dataset.val);
-    document.getElementById(group + '-val').value = val;
-    document.querySelectorAll('[data-group="' + group + '"]').forEach(function(b) {
-      var bVal = parseInt(b.dataset.val);
-      b.classList.toggle('text-yellow-400', bVal <= val);
-      b.classList.toggle('text-gray-600',   bVal >  val);
-    });
-  });
-});
-
 // RAWG search
 function doSearch() {
   var q = document.getElementById('rawg-search').value.trim();

--- a/app/templates/playing/index.html
+++ b/app/templates/playing/index.html
@@ -1,16 +1,9 @@
 {% extends "base.html" %}
+{% from "macros.html" import stars %}
 {% block title %}Playing — Game Journal{% endblock %}
 
 {% block content %}
 <h1 class="text-2xl font-bold mb-8">Active Library</h1>
-
-{% macro stars(value, max=5) %}
-  <span class="text-yellow-400 tracking-tight">
-    {% for i in range(1, max + 1) %}
-      {% if value and i <= value %}★{% else %}<span class="text-gray-600">★</span>{% endif %}
-    {% endfor %}
-  </span>
-{% endmacro %}
 
 {% macro status_badge(status) %}
   {% if status == "Playing" %}
@@ -86,8 +79,9 @@
     <!-- Check-in button -->
     <div class="mt-2 border-t border-gray-800 pt-2">
       <button type="button"
-              onclick="openCheckinModal('{{ url_for('playing.checkin', game_id=game.id) }}', '{{ game.name }}')"
-              class="text-xs text-gray-500 hover:text-indigo-400 transition-colors">
+              class="js-checkin-btn text-xs text-gray-500 hover:text-indigo-400 transition-colors"
+              data-action="{{ url_for('playing.checkin', game_id=game.id) }}"
+              data-name="{{ game.name }}">
         + Check In
       </button>
     </div>
@@ -269,6 +263,12 @@
 </div>
 
 <script>
+document.querySelectorAll('.js-checkin-btn').forEach(function(btn) {
+  btn.addEventListener('click', function() {
+    openCheckinModal(this.dataset.action, this.dataset.name);
+  });
+});
+
 function openCheckinModal(action, gameName) {
   // Reset form
   document.getElementById('checkin-form').action = action;
@@ -295,19 +295,6 @@ function closeCheckinModal() {
   document.getElementById('checkin-modal').classList.add('hidden');
 }
 
-// Star rating handler
-document.querySelectorAll('.star-btn').forEach(function(btn) {
-  btn.addEventListener('click', function() {
-    var group = this.dataset.group;
-    var val   = parseInt(this.dataset.val);
-    document.getElementById(group + '-val').value = val;
-    document.querySelectorAll('[data-group="' + group + '"]').forEach(function(b) {
-      var bVal = parseInt(b.dataset.val);
-      b.classList.toggle('text-yellow-400', bVal <= val);
-      b.classList.toggle('text-gray-600',   bVal >  val);
-    });
-  });
-});
 </script>
 
 {% endblock %}

--- a/app/utils/helpers.py
+++ b/app/utils/helpers.py
@@ -1,0 +1,12 @@
+def _int(value):
+    try:
+        return int(value) if value else None
+    except (ValueError, TypeError):
+        return None
+
+
+def _float(value):
+    try:
+        return float(value) if value else None
+    except (ValueError, TypeError):
+        return None


### PR DESCRIPTION
Closes #22

## Summary

- **`app/utils/helpers.py`** (new) — centralizes `_int()` and `_float()`, removing the duplicate `_int()` that lived in both `playing.py` and `backlog.py`
- **`app/models.py`** — adds `STATUSES` list next to the `status` Enum column; `playing.py` now imports it from there instead of defining it locally
- **`app/templates/macros.html`** (new) — single home for the `stars(value, max=5)` display macro; previously copy-pasted in `playing/index.html` and inlined (with slight variations) in `detail.html`, `main/index.html`, and `backlog/play_next.html`
- **`app/templates/base.html`** — adds `{% block scripts %}` before `</body>` containing the star-rating click handler; removes the identical JS block that was duplicated across 4 templates
- **Bug fix** — `hours_played` in the checkin route was passed as a raw string; now uses `_float()` so values like `0.5` round-trip correctly through the `Numeric(5,1)` column
- **Security fix** — check-in button no longer injects `{{ game.name }}` into an inline `onclick` string (broken by names with quotes, e.g. *Assassin's Creed*); uses `data-action` / `data-name` attributes read by an event listener

## Test plan

- [x] Visit `/playing/` — check-in modal opens for each game; star ratings work; game names with apostrophes are handled correctly
- [x] Submit a check-in with `0.5` hours — value saves and displays as `0.5h`
- [x] Visit `/playing/add` and `/backlog/add` — star ratings work; RAWG search works
- [x] Visit `/playing/<id>` — enjoyment/motivation/overall_rating/difficulty stars render via macro
- [x] Visit `/backlog/play-next` and Dashboard — hype stars render via macro (solid ★ in yellow/gray, not ★/☆)
- [x] Visit `/playing/<id>/finish` — star ratings work

🤖 Generated with [Claude Code](https://claude.com/claude-code)