### PR TITLE
fix: remove /playing/add — games enter only via backlog (issue #24)

### DIFF
--- a/app/blueprints/playing.py
+++ b/app/blueprints/playing.py
@@ -32,40 +32,6 @@ def detail(game_id):
     return render_template("playing/detail.html", game=game, statuses=STATUSES)
 
 
-@playing_bp.route("/add", methods=["GET", "POST"])
-def add():
-    if request.method == "POST":
-        name = request.form.get("name", "").strip()
-        if not name:
-            flash("Game name is required.", "error")
-            return redirect(url_for("playing.add"))
-
-        game = Game(
-            name=name,
-            section="active",
-            status=request.form.get("status", "Playing"),
-            enjoyment=_int(request.form.get("enjoyment")),
-            motivation=_int(request.form.get("motivation")),
-            notes=request.form.get("notes", "").strip() or None,
-            rawg_id=_int(request.form.get("rawg_id")),
-            cover_url=request.form.get("cover_url") or None,
-            release_year=_int(request.form.get("release_year")),
-            genres=request.form.get("genres") or None,
-            platforms=request.form.get("platforms") or None,
-        )
-        db.session.add(game)
-        try:
-            db.session.commit()
-            flash(f"'{game.name}' added to active library.", "success")
-            return redirect(url_for("playing.index"))
-        except Exception:
-            db.session.rollback()
-            flash("Something went wrong. Please try again.", "error")
-            return redirect(url_for("playing.add"))
-
-    return render_template("playing/form.html", game=None, statuses=STATUSES)
-
-
 @playing_bp.route("/<int:game_id>/edit", methods=["GET", "POST"])
 def edit(game_id):
     game = db.get_or_404(Game, game_id)

--- a/app/templates/playing/form.html
+++ b/app/templates/playing/form.html
@@ -1,12 +1,12 @@
 {% extends "base.html" %}
-{% block title %}{{ "Edit" if game else "Add Game" }} — Game Journal{% endblock %}
+{% block title %}Edit Game — Game Journal{% endblock %}
 
 {% block content %}
 <div class="max-w-lg">
-  <h1 class="text-2xl font-bold mb-6">{{ "Edit" if game else "Add Game" }}</h1>
+  <h1 class="text-2xl font-bold mb-6">Edit Game</h1>
 
   <form method="post"
-        action="{{ url_for('playing.edit', game_id=game.id) if game else url_for('playing.add') }}">
+        action="{{ url_for('playing.edit', game_id=game.id) }}">
 
     <!-- RAWG search -->
     <div class="mb-5">
@@ -30,17 +30,17 @@
     </div>
 
     <!-- Hidden RAWG metadata -->
-    <input type="hidden" name="rawg_id"      id="rawg_id"      value="{{ game.rawg_id or '' if game else '' }}">
-    <input type="hidden" name="cover_url"    id="cover_url"    value="{{ game.cover_url or '' if game else '' }}">
-    <input type="hidden" name="release_year" id="release_year" value="{{ game.release_year or '' if game else '' }}">
-    <input type="hidden" name="genres"       id="genres"       value="{{ game.genres or '' if game else '' }}">
-    <input type="hidden" name="platforms"    id="platforms"    value="{{ game.platforms or '' if game else '' }}">
+    <input type="hidden" name="rawg_id"      id="rawg_id"      value="{{ game.rawg_id or '' }}">
+    <input type="hidden" name="cover_url"    id="cover_url"    value="{{ game.cover_url or '' }}">
+    <input type="hidden" name="release_year" id="release_year" value="{{ game.release_year or '' }}">
+    <input type="hidden" name="genres"       id="genres"       value="{{ game.genres or '' }}">
+    <input type="hidden" name="platforms"    id="platforms"    value="{{ game.platforms or '' }}">
 
     <!-- Name -->
     <div class="mb-4">
       <label class="block text-sm text-gray-400 mb-1" for="name">Game name <span class="text-red-400">*</span></label>
       <input id="name" name="name" type="text" required
-             value="{{ game.name if game else '' }}"
+             value="{{ game.name }}"
              class="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-indigo-500">
     </div>
 
@@ -62,20 +62,20 @@
         <div class="flex gap-1" id="enjoyment-stars">
           {% for i in range(1, 6) %}
             <button type="button" data-group="enjoyment" data-val="{{ i }}"
-                    class="star-btn text-2xl {{ 'text-yellow-400' if game and game.enjoyment and i <= game.enjoyment else 'text-gray-600' }} hover:text-yellow-300 transition-colors">★</button>
+                    class="star-btn text-2xl {{ 'text-yellow-400' if game.enjoyment and i <= game.enjoyment else 'text-gray-600' }} hover:text-yellow-300 transition-colors">★</button>
           {% endfor %}
         </div>
-        <input type="hidden" name="enjoyment" id="enjoyment-val" value="{{ game.enjoyment or '' if game else '' }}">
+        <input type="hidden" name="enjoyment" id="enjoyment-val" value="{{ game.enjoyment or '' }}">
       </div>
       <div>
         <label class="block text-sm text-gray-400 mb-2">Motivation</label>
         <div class="flex gap-1" id="motivation-stars">
           {% for i in range(1, 6) %}
             <button type="button" data-group="motivation" data-val="{{ i }}"
-                    class="star-btn text-2xl {{ 'text-yellow-400' if game and game.motivation and i <= game.motivation else 'text-gray-600' }} hover:text-yellow-300 transition-colors">★</button>
+                    class="star-btn text-2xl {{ 'text-yellow-400' if game.motivation and i <= game.motivation else 'text-gray-600' }} hover:text-yellow-300 transition-colors">★</button>
           {% endfor %}
         </div>
-        <input type="hidden" name="motivation" id="motivation-val" value="{{ game.motivation or '' if game else '' }}">
+        <input type="hidden" name="motivation" id="motivation-val" value="{{ game.motivation or '' }}">
       </div>
     </div>
 
@@ -83,13 +83,13 @@
     <div class="mb-6">
       <label class="block text-sm text-gray-400 mb-1" for="notes">Notes</label>
       <textarea id="notes" name="notes" rows="4"
-                class="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-indigo-500 resize-y">{{ game.notes or '' if game else '' }}</textarea>
+                class="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-indigo-500 resize-y">{{ game.notes or '' }}</textarea>
     </div>
 
     <div class="flex gap-3">
       <button type="submit"
               class="px-5 py-2 bg-indigo-700 hover:bg-indigo-600 rounded text-sm font-medium transition-colors">
-        {{ "Save changes" if game else "Add game" }}
+        Save changes
       </button>
       <a href="{{ url_for('playing.index') }}"
          class="px-5 py-2 bg-gray-800 hover:bg-gray-700 rounded text-sm transition-colors">


### PR DESCRIPTION
## Summary

- Removes the `GET/POST /playing/add` route and `add()` function from `playing.py`
- Simplifies `playing/form.html` — strips all add-mode conditionals since it's now edit-only
- Games must be added to the backlog first and promoted to active via the existing promote flow

Closes #24

## Test plan

- [x] Navigating to `/playing/add` returns a 404
- [x] Editing an existing active game via `/playing/<id>/edit` still works correctly
- [x] Adding a game to the backlog and promoting it to active still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)