### PR TITLE
feat: many-to-many categories with RAWG auto-select (issue #15)

### DIFF
--- a/app/blueprints/playing.py
+++ b/app/blueprints/playing.py
@@ -53,8 +53,9 @@ def edit(game_id):
         game.mood_story        = _int(request.form.get("mood_story"))
         game.mood_action       = _int(request.form.get("mood_action"))
         game.mood_exploration  = _int(request.form.get("mood_exploration"))
-        game.notes             = request.form.get("notes", "").strip() or None
-        game.category_id       = _int(request.form.get("category_id"))
+        game.notes      = request.form.get("notes", "").strip() or None
+        cat_ids = [_int(v) for v in request.form.getlist("category_ids") if v]
+        game.categories = Category.query.filter(Category.id.in_(cat_ids)).all() if cat_ids else []
         # Only overwrite RAWG fields if the form sent something new
         game.cover_url    = request.form.get("cover_url")    or game.cover_url
         game.rawg_id      = _int(request.form.get("rawg_id")) or game.rawg_id

--- a/app/seeds.py
+++ b/app/seeds.py
@@ -156,6 +156,7 @@ def seed_command():
 
     click.echo("Clearing existing data...")
     db.session.execute(db.text("SET FOREIGN_KEY_CHECKS=0"))
+    db.session.execute(db.text("DELETE FROM game_categories"))
     Game.query.delete()
     Category.query.delete()
     db.session.execute(db.text("SET FOREIGN_KEY_CHECKS=1"))
@@ -173,7 +174,9 @@ def seed_command():
     for data, cat_name in BACKLOG_GAMES:
         click.echo(f"  {data['name']}...")
         meta = _rawg_meta(data["name"])
-        db.session.add(Game(**{**data, **meta, "rank": 0, "category_id": cats[cat_name].id}))
+        game = Game(**{**data, **meta, "rank": 0})
+        db.session.add(game)
+        game.categories = [cats[cat_name]]
 
     db.session.commit()
     click.echo(f"Done. {len(BACKLOG_GAMES)} backlog games seeded.")

--- a/app/templates/backlog/add.html
+++ b/app/templates/backlog/add.html
@@ -40,17 +40,20 @@
              class="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-indigo-500">
     </div>
 
-    <!-- Category -->
+    <!-- Categories -->
     <div class="mb-6">
-      <label class="block text-sm text-gray-400 mb-1" for="category_id">Category</label>
-      <select id="category_id" name="category_id"
-              class="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-indigo-500">
-        <option value="">— Uncategorized —</option>
+      <label class="block text-sm text-gray-400 mb-2">Categories</label>
+      <div class="flex flex-col gap-1.5" id="category-checkboxes">
         {% for cat in categories %}
-          <option value="{{ cat.id }}" data-genre="{{ cat.name }}">{{ cat.name }}</option>
+          <label class="flex items-center gap-2 cursor-pointer select-none">
+            <input type="checkbox" name="category_ids" value="{{ cat.id }}"
+                   data-genre="{{ cat.name }}"
+                   class="w-4 h-4 accent-indigo-500">
+            <span class="text-sm text-gray-300">{{ cat.name }}</span>
+          </label>
         {% endfor %}
-      </select>
-      <p class="text-xs text-gray-600 mt-1">
+      </div>
+      <p class="text-xs text-gray-600 mt-2">
         <a href="{{ url_for('backlog.categories') }}" class="hover:text-gray-400">Manage categories →</a>
       </p>
     </div>
@@ -173,6 +176,12 @@ function fillFromRawg(g) {
   }
   document.getElementById('rawg-results').classList.add('hidden');
   document.getElementById('rawg-search').value = '';
+
+  // Auto-check categories matching RAWG genres
+  var genres = (g.genres || '').split(', ').map(function(s) { return s.trim(); });
+  document.querySelectorAll('#category-checkboxes input[type="checkbox"]').forEach(function(cb) {
+    cb.checked = genres.indexOf(cb.dataset.genre) !== -1;
+  });
 }
 
 document.addEventListener('click', function(e) {

--- a/app/templates/backlog/index.html
+++ b/app/templates/backlog/index.html
@@ -53,9 +53,7 @@
 </li>
 {% endmacro %}
 
-{% set any_games = categories | selectattr('games') | list or uncategorized %}
-
-{% if not any_games %}
+{% if not has_games %}
   <p class="text-gray-500">
     Backlog is empty.
     <a href="{{ url_for('backlog.add') }}" class="text-indigo-400 hover:underline">Add a game.</a>
@@ -63,11 +61,12 @@
 {% endif %}
 
 {% for cat in categories %}
-  {% if cat.games %}
+  {% set backlog_games = cat.games | selectattr('section', 'equalto', 'backlog') | list %}
+  {% if backlog_games %}
   <section class="mb-8">
     <h2 class="text-sm font-semibold text-gray-400 uppercase tracking-wider mb-2">{{ cat.name }}</h2>
     <ul class="flex flex-col gap-2">
-      {% for game in cat.games %}
+      {% for game in backlog_games %}
         {{ game_row(game) }}
       {% endfor %}
     </ul>

--- a/app/templates/backlog/play_next.html
+++ b/app/templates/backlog/play_next.html
@@ -59,9 +59,9 @@
             <span class="text-xs font-medium text-yellow-400 bg-yellow-900/40 px-1.5 py-0.5 rounded">On Hold</span>
           {% endif %}
         {% else %}
-          {% if game.category %}
-            <span class="text-xs text-gray-500 bg-gray-700 px-1.5 py-0.5 rounded">{{ game.category.name }}</span>
-          {% endif %}
+          {% for cat in game.categories %}
+            <span class="text-xs text-gray-500 bg-gray-700 px-1.5 py-0.5 rounded">{{ cat.name }}</span>
+          {% endfor %}
         {% endif %}
         {% if game.estimated_length %}
           <span class="text-xs text-gray-400">{{ game.estimated_length }}</span>

--- a/app/templates/main/index.html
+++ b/app/templates/main/index.html
@@ -44,9 +44,9 @@
       <div class="flex-1 min-w-0">
         <p class="font-medium truncate">{{ game.name }}</p>
         <div class="flex items-center gap-2 mt-0.5">
-          {% if game.category %}
-            <span class="text-xs text-gray-500">{{ game.category.name }}</span>
-          {% endif %}
+          {% for cat in game.categories %}
+            <span class="text-xs text-gray-500">{{ cat.name }}</span>
+          {% endfor %}
           {% if game.estimated_length %}
             <span class="text-xs text-gray-600">{{ game.estimated_length }}</span>
           {% endif %}

--- a/app/templates/playing/detail.html
+++ b/app/templates/playing/detail.html
@@ -29,8 +29,8 @@
         {% if game.release_year %}
           <p class="text-sm text-gray-500 mt-1">{{ game.release_year }}</p>
         {% endif %}
-        {% if game.category %}
-          <p class="text-sm text-gray-500">{{ game.category.name }}</p>
+        {% if game.categories %}
+          <p class="text-sm text-gray-500">{{ game.categories | map(attribute='name') | join(', ') }}</p>
         {% endif %}
       </div>
       <div class="flex gap-2 flex-wrap mt-2">

--- a/app/templates/playing/form.html
+++ b/app/templates/playing/form.html
@@ -108,17 +108,20 @@
       </div>
     </div>
 
-    <!-- Category -->
+    <!-- Categories -->
     {% if categories %}
     <div class="mb-4">
-      <label class="block text-sm text-gray-400 mb-1" for="category_id">Category</label>
-      <select id="category_id" name="category_id"
-              class="w-full bg-gray-800 border border-gray-700 rounded px-3 py-2 text-sm focus:outline-none focus:border-indigo-500">
-        <option value="">— Uncategorized —</option>
+      <label class="block text-sm text-gray-400 mb-2">Categories</label>
+      <div class="flex flex-col gap-1.5">
         {% for cat in categories %}
-          <option value="{{ cat.id }}" {{ 'selected' if game.category_id == cat.id }}>{{ cat.name }}</option>
+          <label class="flex items-center gap-2 cursor-pointer select-none">
+            <input type="checkbox" name="category_ids" value="{{ cat.id }}"
+                   {{ 'checked' if cat in game.categories }}
+                   class="w-4 h-4 accent-indigo-500">
+            <span class="text-sm text-gray-300">{{ cat.name }}</span>
+          </label>
         {% endfor %}
-      </select>
+      </div>
     </div>
     {% endif %}
 

--- a/app/templates/playing/index.html
+++ b/app/templates/playing/index.html
@@ -66,8 +66,8 @@
       <p class="text-xs text-gray-400 line-clamp-3 mt-1">{{ game.notes }}</p>
     {% endif %}
 
-    {% if game.category %}
-      <p class="text-xs text-gray-600 mt-auto pt-2">{{ game.category.name }}</p>
+    {% if game.categories %}
+      <p class="text-xs text-gray-600 mt-auto pt-2">{{ game.categories | map(attribute='name') | join(', ') }}</p>
     {% endif %}
 
     <!-- Check-in button -->


### PR DESCRIPTION
## Summary

- Games can now belong to multiple categories
- Picking a game from RAWG search auto-checks matching category checkboxes
- Play next scoring uses the best (lowest rank) category across all assigned categories

## ⚠️ Migration SQL — run before deploying

```sql
-- 1. Create join table
CREATE TABLE game_categories (
  game_id     INT NOT NULL,
  category_id INT NOT NULL,
  PRIMARY KEY (game_id, category_id),
  FOREIGN KEY (game_id)     REFERENCES games(id)      ON DELETE CASCADE,
  FOREIGN KEY (category_id) REFERENCES categories(id) ON DELETE CASCADE
);

-- 2. Migrate existing single-category data
INSERT INTO game_categories (game_id, category_id)
SELECT id, category_id FROM games WHERE category_id IS NOT NULL;

-- 3. Find the FK constraint name
SELECT CONSTRAINT_NAME FROM information_schema.KEY_COLUMN_USAGE
WHERE TABLE_NAME = 'games' AND COLUMN_NAME = 'category_id' AND TABLE_SCHEMA = DATABASE();

-- 4. Drop FK and column (replace <constraint_name> with result above)
ALTER TABLE games DROP FOREIGN KEY <constraint_name>;
ALTER TABLE games DROP COLUMN category_id;
```

## Changes

- **`app/models.py`**: `game_categories` association table; `Game.categories` and `Category.games` use `secondary` M2M; `category_id` column removed; `to_dict()` emits `category_ids` list
- **`app/blueprints/backlog.py`**: `_play_next_score` uses `min(c.rank …)`; uncategorized filter uses `~Game.categories.any()`; `add()` parses `category_ids` list; passes `has_games` flag to template
- **`app/blueprints/playing.py`**: `edit()` parses `category_ids` list and assigns via relationship
- **`app/seeds.py`**: wipe step clears `game_categories`; seed assigns via relationship
- **`app/templates/backlog/add.html`**: `<select>` → checkboxes; `fillFromRawg()` auto-checks genres matching category names
- **`app/templates/backlog/index.html`**: filters `cat.games` to backlog section; uses `has_games` flag
- **`app/templates/backlog/play_next.html`**: shows all category badges
- **`app/templates/playing/form.html`**: `<select>` → checkboxes, pre-checked from `game.categories`
- **`app/templates/playing/index.html`**, **`detail.html`**, **`main/index.html`**: updated to iterate `game.categories`

## Test plan

- [x] Run migration SQL
- [x] `python run.py` starts without errors
- [x] Add backlog game with RAWG search → correct genre categories auto-checked
- [x] Add backlog game with 2+ categories → appears under both on backlog index
- [x] Promote game → categories preserved in active library
- [x] Edit active game → category checkboxes show current selections
- [x] Play Next score reflects best category rank when game is in multiple categories
- [x] `flask seed` completes without error

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)