### PR TITLE
feat: mood insight weights in play-next scoring (issue #37)

### DIFF
--- a/app/blueprints/main.py
+++ b/app/blueprints/main.py
@@ -1,6 +1,6 @@
 import os
 from flask import Blueprint, render_template, jsonify, request
-from app.models import Game
+from app.models import Game, MoodPreferences
 
 main_bp = Blueprint("main", __name__)
 
@@ -14,13 +14,14 @@ def index():
 
     # Top 5 games from the dynamic play-next scoring
     from app.blueprints.backlog import _play_next_score
+    prefs = MoodPreferences.get()
     backlog_games = Game.query.filter_by(section="backlog").all()
     active_games = (
         Game.query
         .filter(Game.section == "active", Game.status.in_(["Playing", "On Hold"]))
         .all()
     )
-    play_next = sorted(backlog_games + active_games, key=_play_next_score, reverse=True)[:5]
+    play_next = sorted(backlog_games + active_games, key=lambda g: _play_next_score(g, prefs), reverse=True)[:5]
 
     return render_template(
         "main/index.html",

--- a/app/models.py
+++ b/app/models.py
@@ -172,6 +172,28 @@ class Game(db.Model):
         return f"<Game {self.name!r} [{self.section}/{self.status}]>"
 
 
+class MoodPreferences(db.Model):
+    """Singleton row storing the user's current mood-dimension weights for play-next scoring."""
+    __tablename__ = "mood_preferences"
+
+    id               = db.Column(db.Integer, primary_key=True, default=1)
+    mood_chill       = db.Column(db.Integer, nullable=False, default=0)
+    mood_intense     = db.Column(db.Integer, nullable=False, default=0)
+    mood_story       = db.Column(db.Integer, nullable=False, default=0)
+    mood_action      = db.Column(db.Integer, nullable=False, default=0)
+    mood_exploration = db.Column(db.Integer, nullable=False, default=0)
+
+    @classmethod
+    def get(cls):
+        """Return the singleton row, creating it if it doesn't exist."""
+        prefs = cls.query.first()
+        if prefs is None:
+            prefs = cls(id=1)
+            db.session.add(prefs)
+            db.session.commit()
+        return prefs
+
+
 class CheckIn(db.Model):
     __tablename__ = "checkins"
 

--- a/app/templates/backlog/categories.html
+++ b/app/templates/backlog/categories.html
@@ -55,6 +55,32 @@
   {% else %}
   <p class="text-gray-500 text-sm">No categories yet.</p>
   {% endif %}
+
+  <!-- Mood Preferences -->
+  <div class="mt-10">
+    <h2 class="text-base font-semibold text-gray-300 mb-1">Mood Preferences</h2>
+    <p class="text-xs text-gray-500 mb-4">Set sliders to reflect your current mood — games that match score higher in Play Next.</p>
+    <form method="post" action="{{ url_for('backlog.save_mood_preferences') }}">
+      <div class="space-y-3">
+        {% for mood, label, color in [('chill', 'Chill', 'text-sky-400'), ('intense', 'Intense', 'text-red-400'),
+                                      ('story', 'Story', 'text-purple-400'), ('action', 'Action', 'text-orange-400'),
+                                      ('exploration', 'Exploration', 'text-green-400')] %}
+        <div class="flex items-center gap-3">
+          <span class="w-24 text-xs {{ color }} shrink-0">{{ label }}</span>
+          <input type="range" name="mood_{{ mood }}" id="pref_mood_{{ mood }}"
+                 min="0" max="5" value="{{ prefs['mood_' ~ mood] }}"
+                 class="flex-1 accent-indigo-500"
+                 oninput="document.getElementById('pref_mood_{{ mood }}_val').textContent = this.value">
+          <span id="pref_mood_{{ mood }}_val" class="w-4 text-xs text-gray-400 text-right shrink-0">{{ prefs['mood_' ~ mood] }}</span>
+        </div>
+        {% endfor %}
+      </div>
+      <button type="submit"
+              class="mt-4 px-4 py-2 bg-indigo-700 hover:bg-indigo-600 rounded text-sm transition-colors">
+        Save preferences
+      </button>
+    </form>
+  </div>
 </div>
 
 <script>


### PR DESCRIPTION
Closes #37

## Summary
- Adds a `MoodPreferences` singleton model to persist the user's current mood-dimension weights (chill, intense, story, action, exploration — each 0–5)
- Updates `_play_next_score()` to compute a dot-product between a game's mood sliders and the user's preferences, contributing up to **+30 pts** to the play-next score
- Adds a **Mood Preferences** section at the bottom of the Categories page with sliders and a Save button
- Dashboard and Play Next page both reflect the current preferences

## How the scoring works
`dot = Σ (game.mood_X × prefs.mood_X)` across 5 dimensions  
Max dot = 5 × 5 × 5 = 125 → scaled to 0–30 pts (`int(dot / 125 * 30)`)

## Migration required
Run this before deploying:
```sql
CREATE TABLE mood_preferences (
  id INT NOT NULL DEFAULT 1 PRIMARY KEY,
  mood_chill INT NOT NULL DEFAULT 0,
  mood_intense INT NOT NULL DEFAULT 0,
  mood_story INT NOT NULL DEFAULT 0,
  mood_action INT NOT NULL DEFAULT 0,
  mood_exploration INT NOT NULL DEFAULT 0
);
```
The `MoodPreferences.get()` classmethod auto-creates the singleton row on first access if it doesn't exist.

## Test plan
- [x] Run migration SQL
- [x] Go to Categories → see Mood Preferences sliders at the bottom
- [x] Set some sliders and save — flash confirms success
- [x] Go to Play Next — games with matching mood profiles score higher

🤖 Generated with [Claude Code](https://claude.com/claude-code)