### PR TITLE
feat: profile config & session switcher (issue #42)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,4 @@ FLASK_ENV=production   # set to "development" locally
 RAWG_API_KEY=your-rawg-api-key-here
 TAILSCALE_IP=100.x.x.x
 PORT=5000
+PROFILES=Player 1,Player 2   # comma-separated profile names; first is the default

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,5 +1,5 @@
 import os
-from flask import Flask, render_template
+from flask import Flask, render_template, session
 from flask_sqlalchemy import SQLAlchemy
 from config import config
 
@@ -26,6 +26,14 @@ def create_app(config_name=None):
 
     from app.seeds import seed_command
     app.cli.add_command(seed_command)
+
+    @app.context_processor
+    def inject_profile():
+        profiles = app.config["PROFILES"]
+        current = session.get("profile")
+        if current not in profiles:
+            current = profiles[0]
+        return {"current_profile": current, "profiles": profiles}
 
     @app.errorhandler(404)
     def not_found(e):

--- a/app/blueprints/main.py
+++ b/app/blueprints/main.py
@@ -1,5 +1,5 @@
 import os
-from flask import Blueprint, render_template, jsonify, request
+from flask import Blueprint, render_template, jsonify, request, session, redirect, current_app
 from app.models import Game, MoodPreferences
 
 main_bp = Blueprint("main", __name__)
@@ -31,6 +31,15 @@ def index():
         completed_count=completed_count,
         play_next=play_next,
     )
+
+
+@main_bp.route("/switch-profile", methods=["POST"])
+def switch_profile():
+    profiles = current_app.config["PROFILES"]
+    name = request.form.get("profile", "").strip()
+    if name in profiles:
+        session["profile"] = name
+    return redirect(request.referrer or "/")
 
 
 @main_bp.route("/api/games/search")

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -19,6 +19,37 @@
        class="text-sm transition-colors {{ 'text-white font-medium' if request.path.startswith('/backlog') and not request.path.startswith('/backlog/play-next') else 'text-gray-400 hover:text-white' }}">Backlog</a>
     <a href="{{ url_for('backlog.play_next') }}"
        class="text-sm transition-colors {{ 'text-white font-medium' if request.path.startswith('/backlog/play-next') else 'text-gray-400 hover:text-white' }}">Play Next</a>
+
+    <!-- Profile switcher -->
+    {% if profiles | length > 1 %}
+    <div class="ml-auto relative" id="profile-menu">
+      <button type="button" onclick="document.getElementById('profile-dropdown').classList.toggle('hidden')"
+              class="flex items-center gap-1.5 text-sm text-gray-300 hover:text-white transition-colors px-3 py-1 rounded bg-gray-800 hover:bg-gray-700">
+        <span>{{ current_profile }}</span>
+        <svg class="w-3 h-3 text-gray-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/>
+        </svg>
+      </button>
+      <div id="profile-dropdown"
+           class="hidden absolute right-0 mt-1 w-40 bg-gray-800 border border-gray-700 rounded shadow-lg z-50">
+        {% for profile in profiles %}
+          {% if profile == current_profile %}
+            <p class="px-4 py-2 text-sm text-indigo-400 font-medium">{{ profile }} ✓</p>
+          {% else %}
+            <form method="post" action="{{ url_for('main.switch_profile') }}">
+              <input type="hidden" name="profile" value="{{ profile }}">
+              <button type="submit"
+                      class="w-full text-left px-4 py-2 text-sm text-gray-300 hover:bg-gray-700 hover:text-white transition-colors">
+                {{ profile }}
+              </button>
+            </form>
+          {% endif %}
+        {% endfor %}
+      </div>
+    </div>
+    {% else %}
+    <span class="ml-auto text-sm text-gray-600">{{ current_profile }}</span>
+    {% endif %}
   </nav>
 
   <main class="px-6 py-8 max-w-5xl mx-auto">
@@ -39,6 +70,14 @@
 
 {% block scripts %}
 <script>
+// Close profile dropdown when clicking outside
+document.addEventListener('click', function(e) {
+  var menu = document.getElementById('profile-menu');
+  if (menu && !menu.contains(e.target)) {
+    document.getElementById('profile-dropdown').classList.add('hidden');
+  }
+});
+
 // Star rating handler — shared across all pages with .star-btn elements.
 document.querySelectorAll('.star-btn').forEach(function(btn) {
   btn.addEventListener('click', function() {

--- a/config.py
+++ b/config.py
@@ -8,6 +8,11 @@ class Config:
     SECRET_KEY = os.environ.get("FLASK_SECRET_KEY", "change-me")
     SQLALCHEMY_DATABASE_URI = os.environ.get("DATABASE_URL")
     SQLALCHEMY_TRACK_MODIFICATIONS = False
+    PROFILES = [
+        p.strip()
+        for p in os.environ.get("PROFILES", "Player 1").split(",")
+        if p.strip()
+    ]
 
 
 class DevelopmentConfig(Config):


### PR DESCRIPTION
Closes #42. Part of #35.

## Summary
- Reads `PROFILES=Alice,Bob` from `.env` into `app.config["PROFILES"]`
- Context processor injects `current_profile` and `profiles` into every template
- `POST /switch-profile` sets `session["profile"]` and redirects back to the referring page
- Profile dropdown appears in the top-right of the nav (hidden when only one profile is configured)
- Defaults to first profile if session is empty or contains an unrecognised name

## Test plan
- [x] Add `PROFILES=Alice,Bob` to `.env` and restart
- [x] See the dropdown appear in the top-right of the nav
- [x] Switch from Alice → Bob — dropdown now shows Bob with a ✓
- [x] Navigate to other pages — profile stays as Bob
- [x] Restart the server — profile persists via cookie
- [x] Remove `PROFILES` from `.env` (or set only one) — dropdown is hidden, profile name shown as dim text

## No DB changes
All pages still show the same data — data scoping comes in #43 onwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)