### PR TITLE
feat: profile_games table, slim Game model (issue #43)

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -4,13 +4,6 @@ from app import db
 STATUSES = ["Playing", "On Hold", "Dropped", "Completed"]
 
 
-game_categories = db.Table(
-    "game_categories",
-    db.Column("game_id",     db.Integer, db.ForeignKey("games.id",      ondelete="CASCADE"), primary_key=True),
-    db.Column("category_id", db.Integer, db.ForeignKey("categories.id", ondelete="CASCADE"), primary_key=True),
-)
-
-
 class Category(db.Model):
     __tablename__ = "categories"
 
@@ -19,99 +12,98 @@ class Category(db.Model):
     # Priority order for play-next scoring (1 = most interested in right now).
     rank = db.Column(db.Integer, nullable=False, default=0)
 
-    # Many categories <-> many games, ordered alphabetically.
-    games = db.relationship(
-        "Game",
-        secondary="game_categories",
-        back_populates="categories",
-        order_by="Game.name",
-    )
-
     def __repr__(self) -> str:
         return f"<Category {self.name!r}>"
 
 
 class Game(db.Model):
+    """Shared game record — RAWG metadata only. Per-profile data lives in ProfileGame."""
     __tablename__ = "games"
 
-    # ------------------------------------------------------------------ #
-    # Core identity                                                        #
-    # ------------------------------------------------------------------ #
-    id   = db.Column(db.Integer, primary_key=True, autoincrement=True)
-    name = db.Column(db.String(200), nullable=False)
+    id           = db.Column(db.Integer,     primary_key=True, autoincrement=True)
+    name         = db.Column(db.String(200), nullable=False)
+    rawg_id      = db.Column(db.Integer,     nullable=True, unique=True)
+    cover_url    = db.Column(db.String(500), nullable=True)
+    release_year = db.Column(db.Integer,     nullable=True)
+    genres       = db.Column(db.String(200), nullable=True)   # "RPG, Action"
+    platforms    = db.Column(db.String(300), nullable=True)   # "PC, PS5"
+    created_at   = db.Column(db.DateTime,   nullable=False, default=datetime.utcnow)
 
-    # Which half of the app this game lives in.
+    # One game can have many per-profile entries (one per profile that tracks it).
+    profile_games = db.relationship(
+        "ProfileGame",
+        back_populates="game",
+        cascade="all, delete-orphan",
+    )
+
+    def to_dict(self) -> dict:
+        return {
+            "id":           self.id,
+            "name":         self.name,
+            "rawg_id":      self.rawg_id,
+            "cover_url":    self.cover_url,
+            "release_year": self.release_year,
+            "genres":       self.genres,
+            "platforms":    self.platforms,
+        }
+
+    def __repr__(self) -> str:
+        return f"<Game {self.name!r}>"
+
+
+class ProfileGame(db.Model):
+    """Per-profile tracking data for a game."""
+    __tablename__ = "profile_games"
+
+    id         = db.Column(db.Integer,      primary_key=True, autoincrement=True)
+    profile_id = db.Column(db.String(100),  nullable=False)
+    game_id    = db.Column(db.Integer,      db.ForeignKey("games.id", ondelete="CASCADE"), nullable=False)
+
+    # ------------------------------------------------------------------ #
+    # Library placement                                                    #
+    # ------------------------------------------------------------------ #
     section = db.Column(
-        db.Enum("active", "backlog", name="section_enum"),
+        db.Enum("active", "backlog", name="pg_section_enum"),
         nullable=False,
     )
-
-    # Lifecycle status — only meaningful for active games.
     status = db.Column(
-        db.Enum("Playing", "On Hold", "Dropped", "Completed", name="status_enum"),
+        db.Enum("Playing", "On Hold", "Dropped", "Completed", name="pg_status_enum"),
         nullable=True,
     )
-
-    # ------------------------------------------------------------------ #
-    # Personal tracking                                                    #
-    # ------------------------------------------------------------------ #
-    enjoyment  = db.Column(db.Integer, nullable=True)   # 1–5; null = unrated
-    motivation = db.Column(db.Integer, nullable=True)   # 1–5; null = unrated
-    notes      = db.Column(db.Text,    nullable=True)
-
-    # ------------------------------------------------------------------ #
-    # Backlog ordering                                                     #
-    # ------------------------------------------------------------------ #
-    rank = db.Column(db.Integer, nullable=False, default=0)
-
-    # Cross-category play-next rank (1 = play first).  Null for games that
-    # pre-date the feature or were added without the survey.
+    rank           = db.Column(db.Integer, nullable=False, default=0)
     play_next_rank = db.Column(db.Integer, nullable=True)
 
     # ------------------------------------------------------------------ #
-    # Play-next survey (backlog only)                                      #
+    # Play-next survey                                                     #
     # ------------------------------------------------------------------ #
-    hype             = db.Column(db.Integer, nullable=True)   # 1–5
+    hype             = db.Column(db.Integer, nullable=True)
     estimated_length = db.Column(
-        db.Enum("Short", "Medium", "Long", "Very Long", name="length_enum"),
+        db.Enum("Short", "Medium", "Long", "Very Long", name="pg_length_enum"),
         nullable=True,
     )
     series_continuity = db.Column(db.Boolean, nullable=True, default=False)
 
-    # Mood blend sliders (0–5 each)
     mood_chill       = db.Column(db.Integer, nullable=True)
     mood_intense     = db.Column(db.Integer, nullable=True)
     mood_story       = db.Column(db.Integer, nullable=True)
     mood_action      = db.Column(db.Integer, nullable=True)
     mood_exploration = db.Column(db.Integer, nullable=True)
 
-    # Many games <-> many categories.
-    categories = db.relationship(
-        "Category",
-        secondary="game_categories",
-        back_populates="games",
-        order_by="Category.rank",
-    )
-
     # ------------------------------------------------------------------ #
-    # RAWG metadata (optional — populated at add time via API lookup)     #
+    # Personal tracking                                                    #
     # ------------------------------------------------------------------ #
-    rawg_id      = db.Column(db.Integer,     nullable=True)
-    cover_url    = db.Column(db.String(500), nullable=True)
-    release_year = db.Column(db.Integer,     nullable=True)
-    genres       = db.Column(db.String(200), nullable=True)   # "RPG, Action"
-    platforms    = db.Column(db.String(300), nullable=True)   # "PC, PS5"
+    notes = db.Column(db.Text, nullable=True)
 
     # ------------------------------------------------------------------ #
     # Finished-game survey                                                 #
     # ------------------------------------------------------------------ #
-    finished         = db.Column(db.Boolean,  nullable=False, default=False)
-    overall_rating   = db.Column(db.Integer,  nullable=True)   # 1–10
+    finished         = db.Column(db.Boolean, nullable=False, default=False)
+    overall_rating   = db.Column(db.Integer, nullable=True)
     would_play_again = db.Column(
-        db.Enum("Yes", "No", "Maybe", name="wpa_enum"), nullable=True
+        db.Enum("Yes", "No", "Maybe", name="pg_wpa_enum"), nullable=True
     )
-    hours_to_finish  = db.Column(db.Integer,  nullable=True)
-    difficulty       = db.Column(db.Integer,  nullable=True)   # 1–5
+    hours_to_finish = db.Column(db.Integer, nullable=True)
+    difficulty      = db.Column(db.Integer, nullable=True)
 
     # ------------------------------------------------------------------ #
     # Timestamps                                                           #
@@ -124,52 +116,16 @@ class Game(db.Model):
         onupdate=datetime.utcnow,
     )
 
-    # Reverse relationship populated by CheckIn model below.
-    checkins = db.relationship(
-        "CheckIn",
-        back_populates="game",
-        order_by="CheckIn.created_at.desc()",
-        cascade="all, delete-orphan",
-    )
+    # ------------------------------------------------------------------ #
+    # Relationships                                                        #
+    # ------------------------------------------------------------------ #
+    game = db.relationship("Game", back_populates="profile_games")
 
-    # ------------------------------------------------------------------ #
-    # Helpers                                                              #
-    # ------------------------------------------------------------------ #
-    def to_dict(self) -> dict:
-        """Serialise to a plain dict for JSON responses (e.g. reorder, search)."""
-        return {
-            "id":           self.id,
-            "name":         self.name,
-            "section":      self.section,
-            "status":       self.status,
-            "enjoyment":    self.enjoyment,
-            "motivation":   self.motivation,
-            "notes":        self.notes,
-            "rank":         self.rank,
-            "category_ids": [c.id for c in self.categories],
-            "rawg_id":          self.rawg_id,
-            "cover_url":        self.cover_url,
-            "release_year":     self.release_year,
-            "genres":           self.genres,
-            "platforms":        self.platforms,
-            "play_next_rank":   self.play_next_rank,
-            "hype":             self.hype,
-            "estimated_length": self.estimated_length,
-            "series_continuity":self.series_continuity,
-            "mood_chill":       self.mood_chill,
-            "mood_intense":     self.mood_intense,
-            "mood_story":       self.mood_story,
-            "mood_action":      self.mood_action,
-            "mood_exploration":  self.mood_exploration,
-            "finished":          self.finished,
-            "overall_rating":    self.overall_rating,
-            "would_play_again":  self.would_play_again,
-            "hours_to_finish":   self.hours_to_finish,
-            "difficulty":        self.difficulty,
-        }
+    # checkins relationship added in issue #47
+    # categories M2M relationship added in issue #46
 
     def __repr__(self) -> str:
-        return f"<Game {self.name!r} [{self.section}/{self.status}]>"
+        return f"<ProfileGame profile={self.profile_id!r} game={self.game_id} [{self.section}/{self.status}]>"
 
 
 class MoodPreferences(db.Model):
@@ -209,8 +165,6 @@ class CheckIn(db.Model):
     hours_played = db.Column(db.Numeric(5, 1), nullable=True)
     status       = db.Column(db.String(20),    nullable=True)
     created_at   = db.Column(db.DateTime, nullable=False, default=datetime.utcnow)
-
-    game = db.relationship("Game", back_populates="checkins")
 
     def __repr__(self) -> str:
         return f"<CheckIn game_id={self.game_id} at={self.created_at}>"

--- a/app/seeds.py
+++ b/app/seeds.py
@@ -2,7 +2,7 @@ import os
 import click
 from flask.cli import with_appcontext
 from app import db
-from app.models import Category, Game
+from app.models import Category, Game, ProfileGame
 
 
 # RAWG genre categories in default rank order (user can reorder via the UI)
@@ -28,18 +28,18 @@ CATEGORIES = [
     "Educational",
 ]
 
-# (game data, category name)
-# Survey fields: hype (1-5), estimated_length, series_continuity,
-#                mood_chill/intense/story/action/exploration (0-5 each)
+# (game RAWG data, profile-specific data)
 BACKLOG_GAMES = [
     (
         {
             "name": "Baldur's Gate 3",
-            "section": "backlog",
-            "status": None,
             "genres": "RPG, Strategy",
             "platforms": "PC, PS5",
             "release_year": 2023,
+        },
+        {
+            "section": "backlog",
+            "status": None,
             "hype": 5,
             "estimated_length": "Very Long",
             "series_continuity": False,
@@ -48,17 +48,19 @@ BACKLOG_GAMES = [
             "mood_story": 5,
             "mood_action": 3,
             "mood_exploration": 4,
+            "rank": 0,
         },
-        "RPG",
     ),
     (
         {
             "name": "Hollow Knight",
-            "section": "backlog",
-            "status": None,
             "genres": "Action, Adventure, Indie",
             "platforms": "PC, Switch, PS4",
             "release_year": 2017,
+        },
+        {
+            "section": "backlog",
+            "status": None,
             "hype": 4,
             "estimated_length": "Medium",
             "series_continuity": False,
@@ -67,17 +69,19 @@ BACKLOG_GAMES = [
             "mood_story": 3,
             "mood_action": 3,
             "mood_exploration": 5,
+            "rank": 0,
         },
-        "Indie",
     ),
     (
         {
             "name": "Celeste",
-            "section": "backlog",
-            "status": None,
             "genres": "Platformer, Indie",
             "platforms": "PC, Switch, PS4",
             "release_year": 2018,
+        },
+        {
+            "section": "backlog",
+            "status": None,
             "hype": 5,
             "estimated_length": "Short",
             "series_continuity": False,
@@ -86,17 +90,19 @@ BACKLOG_GAMES = [
             "mood_story": 3,
             "mood_action": 3,
             "mood_exploration": 2,
+            "rank": 0,
         },
-        "Platformer",
     ),
     (
         {
             "name": "Ori and the Blind Forest",
-            "section": "backlog",
-            "status": None,
             "genres": "Platformer, Adventure",
             "platforms": "PC, Switch, Xbox One",
             "release_year": 2015,
+        },
+        {
+            "section": "backlog",
+            "status": None,
             "hype": 3,
             "estimated_length": "Short",
             "series_continuity": False,
@@ -105,17 +111,19 @@ BACKLOG_GAMES = [
             "mood_story": 4,
             "mood_action": 2,
             "mood_exploration": 3,
+            "rank": 0,
         },
-        "Platformer",
     ),
     (
         {
             "name": "Into the Breach",
-            "section": "backlog",
-            "status": None,
             "genres": "Strategy, Indie",
             "platforms": "PC, Switch",
             "release_year": 2018,
+        },
+        {
+            "section": "backlog",
+            "status": None,
             "hype": 3,
             "estimated_length": "Medium",
             "series_continuity": False,
@@ -124,8 +132,8 @@ BACKLOG_GAMES = [
             "mood_story": 1,
             "mood_action": 2,
             "mood_exploration": 1,
+            "rank": 0,
         },
-        "Strategy",
     ),
 ]
 
@@ -148,6 +156,10 @@ def _rawg_meta(name):
 @with_appcontext
 def seed_command():
     """Wipe and re-seed the database with example data."""
+    # Determine first profile name from env
+    profiles_env = os.environ.get("PROFILES", "Player 1")
+    first_profile = [p.strip() for p in profiles_env.split(",") if p.strip()][0]
+
     use_rawg = bool(os.environ.get("RAWG_API_KEY"))
     if use_rawg:
         click.echo("RAWG key found — cover art will be fetched.")
@@ -156,27 +168,28 @@ def seed_command():
 
     click.echo("Clearing existing data...")
     db.session.execute(db.text("SET FOREIGN_KEY_CHECKS=0"))
-    db.session.execute(db.text("DELETE FROM game_categories"))
+    db.session.execute(db.text("DELETE FROM profile_games"))
+    db.session.execute(db.text("DELETE FROM checkins"))
     Game.query.delete()
     Category.query.delete()
     db.session.execute(db.text("SET FOREIGN_KEY_CHECKS=1"))
     db.session.commit()
 
     click.echo("Creating categories...")
-    cats = {}
     for rank, name in enumerate(CATEGORIES, start=1):
-        c = Category(name=name, rank=rank)
-        db.session.add(c)
-        cats[name] = c
-    db.session.flush()
+        db.session.add(Category(name=name, rank=rank))
+    db.session.commit()
 
-    click.echo("Creating backlog games...")
-    for data, cat_name in BACKLOG_GAMES:
-        click.echo(f"  {data['name']}...")
-        meta = _rawg_meta(data["name"])
-        game = Game(**{**data, **meta, "rank": 0})
+    click.echo(f"Creating backlog games (profile: {first_profile!r})...")
+    for game_data, profile_data in BACKLOG_GAMES:
+        click.echo(f"  {game_data['name']}...")
+        meta = _rawg_meta(game_data["name"])
+        game = Game(**{**game_data, **meta})
         db.session.add(game)
-        game.categories = [cats[cat_name]]
+        db.session.flush()  # get game.id
+
+        pg = ProfileGame(profile_id=first_profile, game_id=game.id, **profile_data)
+        db.session.add(pg)
 
     db.session.commit()
     click.echo(f"Done. {len(BACKLOG_GAMES)} backlog games seeded.")


### PR DESCRIPTION
Closes #43. Part of #35.

## Summary
- `Game` model stripped to RAWG/identity fields only — shared across all profiles, deduped by `rawg_id`
- New `ProfileGame` model holds all per-profile tracking data (`section`, `status`, `hype`, `mood_*`, `notes`, survey fields, etc.), keyed by `profile_id` (VARCHAR matching names in `PROFILES` env var)
- `game_categories` removed from models — will be recreated as per-profile in #46
- `CheckIn.game_id` unchanged — migrated to `profile_game_id` in #47
- `seeds.py` updated to create `Game` + `ProfileGame` separately, seeding to the first profile in `PROFILES`

> **Note:** Routes still reference the old `Game` fields — the app will not function until #44 and #45 update the blueprints.

---

## Migration SQL

Run this against the database **before** deploying:

```sql
-- 1. Create profile_games table
CREATE TABLE profile_games (
    id               INT          NOT NULL AUTO_INCREMENT PRIMARY KEY,
    profile_id       VARCHAR(100) NOT NULL,
    game_id          INT          NOT NULL,
    section          ENUM('active','backlog') NOT NULL,
    status           ENUM('Playing','On Hold','Dropped','Completed') NULL,
    rank             INT          NOT NULL DEFAULT 0,
    play_next_rank   INT          NULL,
    hype             INT          NULL,
    estimated_length ENUM('Short','Medium','Long','Very Long') NULL,
    series_continuity TINYINT(1)  NULL DEFAULT 0,
    mood_chill       INT          NULL,
    mood_intense     INT          NULL,
    mood_story       INT          NULL,
    mood_action      INT          NULL,
    mood_exploration INT          NULL,
    notes            TEXT         NULL,
    finished         TINYINT(1)   NOT NULL DEFAULT 0,
    overall_rating   INT          NULL,
    would_play_again ENUM('Yes','No','Maybe') NULL,
    hours_to_finish  INT          NULL,
    difficulty       INT          NULL,
    created_at       DATETIME     NOT NULL,
    updated_at       DATETIME     NOT NULL,
    FOREIGN KEY (game_id) REFERENCES games(id) ON DELETE CASCADE
);

-- 2. Migrate existing games → profile_games
--    Replace 'Player 1' with the first name in your PROFILES env var
INSERT INTO profile_games (
    profile_id, game_id, section, status, rank, play_next_rank,
    hype, estimated_length, series_continuity,
    mood_chill, mood_intense, mood_story, mood_action, mood_exploration,
    notes, finished, overall_rating, would_play_again, hours_to_finish, difficulty,
    created_at, updated_at
)
SELECT
    'Player 1',
    id, section, status, rank, play_next_rank,
    hype, estimated_length, series_continuity,
    mood_chill, mood_intense, mood_story, mood_action, mood_exploration,
    notes, finished, overall_rating, would_play_again, hours_to_finish, difficulty,
    created_at, updated_at
FROM games;

-- 3. Drop game_categories (recreated per-profile in issue #46)
DROP TABLE IF EXISTS game_categories;

-- 4. Strip per-profile columns from games
ALTER TABLE games
    DROP COLUMN section,
    DROP COLUMN status,
    DROP COLUMN enjoyment,
    DROP COLUMN motivation,
    DROP COLUMN notes,
    DROP COLUMN rank,
    DROP COLUMN play_next_rank,
    DROP COLUMN hype,
    DROP COLUMN estimated_length,
    DROP COLUMN series_continuity,
    DROP COLUMN mood_chill,
    DROP COLUMN mood_intense,
    DROP COLUMN mood_story,
    DROP COLUMN mood_action,
    DROP COLUMN mood_exploration,
    DROP COLUMN finished,
    DROP COLUMN overall_rating,
    DROP COLUMN would_play_again,
    DROP COLUMN hours_to_finish,
    DROP COLUMN difficulty,
    DROP COLUMN updated_at;

-- 5. Add unique constraint on rawg_id (games are now shared/deduped)
ALTER TABLE games ADD UNIQUE KEY uq_rawg_id (rawg_id);
```

## Test plan
- [x] Run migration SQL
- [ ] Verify `profile_games` is populated with existing data assigned to first profile
- [ ] Verify `games` table now only has: id, name, rawg_id, cover_url, release_year, genres, platforms, created_at
- [ ] `flask seed` runs without error
- [ ] App loads (will have route errors until #44/#45 — that's expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)