### PR TITLE
feat: Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.venv/
+__pycache__/
+*.pyc
+*.pyo
+.env
+backups/
+.git/
+deploy/

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,7 @@
 FLASK_SECRET_KEY=your-secret-key-here
-DATABASE_URL=mysql+pymysql://user:password@host/dbname
+# Use your server's Tailscale hostname or IP — not 'localhost' when running via Docker,
+# as localhost inside the container refers to the container itself, not the host machine.
+DATABASE_URL=mysql+pymysql://user:password@your-server-name/dbname
 FLASK_ENV=production   # set to "development" locally
 RAWG_API_KEY=your-rawg-api-key-here
 TAILSCALE_IP=100.x.x.x

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV FLASK_APP=run.py
+
+RUN chmod +x entrypoint.sh
+
+EXPOSE 5000
+
+ENTRYPOINT ["./entrypoint.sh"]

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,5 @@
 import os
+import click
 from flask import Flask, render_template, session
 from flask_sqlalchemy import SQLAlchemy
 from config import config
@@ -30,6 +31,12 @@ def create_app(config_name=None):
     from app.backup import backup_command, restore_command
     app.cli.add_command(backup_command)
     app.cli.add_command(restore_command)
+
+    @app.cli.command("init-db")
+    def init_db_command():
+        """Create database tables if they don't already exist."""
+        db.create_all()
+        click.echo("Database tables ready.")
 
     @app.context_processor
     def inject_profile():

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  game-journal:
+    build: .
+    env_file: .env
+    ports:
+      - "${TAILSCALE_IP}:${PORT:-5000}:5000"
+    restart: unless-stopped

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+flask init-db
+
+exec gunicorn -w 2 -b 0.0.0.0:5000 "app:create_app()"


### PR DESCRIPTION
Closes #38, #58, #59, #60

## Summary
- `Dockerfile` — `python:3.11-slim`, installs requirements, runs `entrypoint.sh`
- `entrypoint.sh` — runs `flask init-db` (creates tables if needed) then starts Gunicorn bound to `0.0.0.0:5000`
- `flask init-db` — new CLI command wrapping `db.create_all()`; safe to run on every startup
- `docker-compose.yml` — port bound to `${TAILSCALE_IP}:${PORT:-5000}:5000` so only Tailscale clients can reach it; loads config from `.env`
- `.dockerignore` — excludes `.venv/`, `.env`, `backups/`, `.git/`, `deploy/`
- `.env.example` — note added: don't use `localhost` as DB host when running via Docker

## Test plan
- [ ] `docker compose build` completes without errors
- [ ] `docker compose up` starts the container and `flask init-db` runs cleanly (check logs)
- [ ] App is reachable at `http://<tailscale-ip>:5000` from a Tailscale-connected device
- [ ] App is **not** reachable from outside Tailscale (port not bound to 0.0.0.0)
- [ ] `docker compose down && docker compose up` — second start-up with existing tables works fine (init-db is a no-op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)