### PR TITLE
fix: fix OpenRC template — absolute paths and safe .env sourcing (issue #63)

### DIFF
--- a/deploy/game-journal.openrc
+++ b/deploy/game-journal.openrc
@@ -1,10 +1,12 @@
 #!/sbin/openrc-run
 
 name="game-journal"
-description="Game Journal"
+description="Game Journal Flask app"
 
+# IMPORTANT: Use absolute paths — tilde (~) is NOT expanded by OpenRC.
+# Example: directory="/home/connor/game-journal"
 directory="/path/to/game-journal"
-command="/path/to/game-journal/.venv/bin/gunicorn"
+command="${directory}/.venv/bin/gunicorn"
 command_args="-w 2 -b <tailscale-ip>:<port> \"app:create_app()\""
 command_user="<your-linux-user>"
 command_background=yes
@@ -15,6 +17,9 @@ depend() {
 }
 
 start_pre() {
-    # Load .env into the environment before gunicorn starts
-    export $(grep -v '^#' "${directory}/.env" | xargs)
+    # Source .env into the environment before gunicorn starts.
+    # 'set -a' exports every variable defined after it automatically.
+    set -a
+    . "${directory}/.env"
+    set +a
 }


### PR DESCRIPTION
Fixes #63

## Problem

Two bugs in the OpenRC template that caused `rc-service game-journal start` to fail:

1. **Tilde not expanded** — OpenRC does not expand `~` in variable assignments. When the user filled in `~/game-journal`, OpenRC resolved `~` to `/root` (since it runs as root), so both the `.env` path and the gunicorn binary path were wrong. Added a prominent comment making clear that absolute paths are required.

2. **Fragile `.env` loading** — `export $(grep -v '^#' .env | xargs)` breaks on values that contain special characters like `@`, `/`, `:`, or spaces — all of which appear in a typical `DATABASE_URL`. Replaced with `set -a; . "${directory}/.env"; set +a`, which sources the file natively and handles all value formats correctly.

## Fix

- Add comment warning that `~` is not expanded — use full absolute paths
- Replace `grep | xargs` env loading with `set -a; . .env; set +a`

## After applying the fix

Re-copy the updated template to `/etc/init.d/game-journal`, fill in the real absolute path (e.g. `/home/connor/game-journal`), your linux user, and the Tailscale IP/port, then restart:

```bash
sudo cp deploy/game-journal.openrc /etc/init.d/game-journal
sudo chmod +x /etc/init.d/game-journal
sudo rc-service game-journal restart
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)